### PR TITLE
selenium 4.38.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,9 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
-  skip: True  # [py<310] 
+  
+  # remove skip [py>=314] when python_abi 3.14 will be availabel for the all deps
+  skip: True  # [py<310 or py>=314] 
   missing_dso_whitelist:  # [osx]
     - '*'                 # [osx]
 
@@ -34,9 +36,6 @@ requirements:
     - certifi >=2025.10.5
     - typing_extensions >=4.15.0,<5.0
     - websocket-client >=1.8.0,<2.0
-  run_constrained:
-    # remove this when python_abi 3.14 will be availabel for the all deps
-    - python_abi >=3.10,<3.14a0
 
 test:
   files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
-  skip: True  # [py<310 or py>=314]
+  skip: True  # [py<310] 
   missing_dso_whitelist:  # [osx]
     - '*'                 # [osx]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,9 @@ requirements:
     - certifi >=2025.10.5
     - typing_extensions >=4.15.0,<5.0
     - websocket-client >=1.8.0,<2.0
+  run_constrained:
+    # remove this when python_abi 3.14 will be availabel for the all deps
+    - python_abi >=3.10,<3.14a0
 
 test:
   files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,23 +1,22 @@
 {% set name = "selenium" %}
-{% set version = "4.24.0" %}
+{% set version = "4.38.0" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 88281e5b5b90fe231868905d5ea745b9ee5e30db280b33498cc73fb0fa06d571
+  sha256: c117af6727859d50f622d6d0785b945c5db3e28a45ec12ad85cee2e7cc84fc4c
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
-  skip: True  # [py<38]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
+  skip: True  # [py<310]
   missing_dso_whitelist:  # [osx]
     - '*'                 # [osx]
 
 requirements:
   build:
-    - {{ compiler('c') }}
     - {{ compiler('rust') }}
   host:
     - python
@@ -27,21 +26,20 @@ requirements:
     - wheel
   run:
     - python
-    - urllib3 >=1.26,<3
-    - trio >=0.17,<1.0
-    - trio-websocket >=0.9,<1.0
-    - certifi >=2021.10.8
-    - typing_extensions >=4.9,<5.0
-    - websocket-client >=1.8,<2.0
+    - urllib3 >=2.5.0,<3.0
+    # - trio >=0.31.0,<1.0
+    - trio >=0.30.0,<1.0
+    - trio-websocket >=0.12.2,<1.0
+    - certifi >=2025.10.5
+    - typing_extensions >=4.15.0,<5.0
+    - websocket-client >=1.8.0,<2.0
+
 
 test:
-  requires:
-    - pip
-  commands:
-    - pip check
   imports:
     - selenium
     - selenium.common
+    - selenium.types
     - selenium.webdriver.common
     - selenium.webdriver.chrome
     - selenium.webdriver.chromium
@@ -53,19 +51,28 @@ test:
     - selenium.webdriver.support
     - selenium.webdriver.webkitgtk
     - selenium.webdriver.wpewebkit
+  requires:
+    - pip
+    - pytest
+  commands:
+    - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+
 
 about:
-  home: https://www.seleniumhq.org/
-  license_file: {{ RECIPE_DIR }}/LICENSE
+  home: https://www.seleniumhq.org
   license: Apache-2.0
   license_family: Apache
-  summary: 'Python bindings for the Selenium WebDriver for automating web browser interaction.'
+  license_file:
+    - LICENSE
+    - NOTICE
+  summary: Python bindings for the Selenium WebDriver for automating web browser interaction
   description: |
     Selenium specifically provides an infrastructure for the W3C WebDriver
     specification — a platform and language-neutral coding interface compatible
     with all major web browsers.
-  dev_url: https://github.com/SeleniumHQ/selenium/
-  doc_url: https://www.selenium.dev/documentation/
+  dev_url: https://github.com/SeleniumHQ/selenium
+  doc_url: https://www.selenium.dev/documentation
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
-  skip: True  # [py<310]
+  skip: True  # [py<310 or py>=314] 
   missing_dso_whitelist:  # [osx]
     - '*'                 # [osx]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,7 @@ build:
 
 requirements:
   build:
+    - {{ compiler('c') }}
     - {{ compiler('rust') }}
   host:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,9 +11,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
-  
-  # remove skip [py>=314] when python_abi 3.14 will be availabel for the all deps
-  skip: True  # [py<310 or py>=314] 
+  skip: True  # [py<310]
   missing_dso_whitelist:  # [osx]
     - '*'                 # [osx]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
-  skip: True  # [py<310 or py>=314] 
+  skip: True  # [py<310 or py>=314]
   missing_dso_whitelist:  # [osx]
     - '*'                 # [osx]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,7 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('rust') }}
   host:
@@ -28,15 +29,15 @@ requirements:
   run:
     - python
     - urllib3 >=2.5.0,<3.0
-    # - trio >=0.31.0,<1.0
-    - trio >=0.30.0,<1.0
+    - trio >=0.31.0,<1.0
     - trio-websocket >=0.12.2,<1.0
     - certifi >=2025.10.5
     - typing_extensions >=4.15.0,<5.0
     - websocket-client >=1.8.0,<2.0
 
-
 test:
+  files:
+    - test_selenium.py
   imports:
     - selenium
     - selenium.common
@@ -58,7 +59,7 @@ test:
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-
+    - pytest -ra -v --tb=short test_selenium.py
 
 about:
   home: https://www.seleniumhq.org

--- a/recipe/test_selenium.py
+++ b/recipe/test_selenium.py
@@ -1,0 +1,92 @@
+
+import os
+import importlib
+import importlib.metadata as ilmd
+import pytest
+
+# Core import should succeed quickly and without side effects
+def test_core_imports():
+    import selenium
+    assert hasattr(selenium, "__version__")
+
+    # Commonly used submodules should be importable
+    import selenium.webdriver
+    import selenium.webdriver.common
+    import selenium.webdriver.remote
+
+    # These are present in Selenium 4.x
+    import selenium.webdriver.chrome
+    import selenium.webdriver.firefox
+    import selenium.webdriver.edge
+    import selenium.webdriver.safari
+
+
+def test_package_version_matches_env_or_metadata():
+    """
+    Fast sanity check that the installed distribution metadata is consistent.
+    If EXPECTED_VERSION is provided in env, ensure it matches.
+    Otherwise, just assert that version is a non-empty string.
+    """
+    dist_version = ilmd.version("selenium")
+    assert isinstance(dist_version, str) and dist_version
+
+    expected = os.environ.get("EXPECTED_VERSION")
+    if expected:
+        assert dist_version == expected, f"{dist_version=} != {expected=}"
+
+
+def test_capabilities_build_chrome():
+    """
+    Build Chrome options and convert to capabilities without launching anything.
+    """
+    from selenium.webdriver.chrome.options import Options as ChromeOptions
+
+    opts = ChromeOptions()
+    # Adding arguments must only mutate internal state; no process is spawned
+    opts.add_argument("--headless=new")
+    opts.add_argument("--disable-gpu")
+
+    caps = opts.to_capabilities()
+    assert isinstance(caps, dict)
+    # W3C capability key should be present
+    assert "browserName" in caps
+    assert caps["browserName"].lower() in {"chrome", "chromium"}
+
+
+def test_capabilities_build_firefox():
+    from selenium.webdriver.firefox.options import Options as FirefoxOptions
+
+    opts = FirefoxOptions()
+    opts.headless = True
+
+    caps = opts.to_capabilities()
+    assert isinstance(caps, dict)
+    assert "browserName" in caps
+    assert caps["browserName"].lower() == "firefox"
+
+
+def test_capabilities_build_edge():
+    from selenium.webdriver.edge.options import Options as EdgeOptions
+
+    opts = EdgeOptions()
+    opts.add_argument("--headless=new")
+
+    caps = opts.to_capabilities()
+    assert isinstance(caps, dict)
+    assert "browserName" in caps
+    # Browser name can be "MicrosoftEdge" or "msedge" depending on Selenium
+    assert caps["browserName"].lower() in {"microsoftedge", "msedge", "edge"}
+
+
+def test_capabilities_build_safari():
+    """
+    Safari has an Options class but no headless support.
+    This test only validates capability dict building.
+    """
+    from selenium.webdriver.safari.options import Options as SafariOptions
+
+    opts = SafariOptions()
+    caps = opts.to_capabilities()
+    assert isinstance(caps, dict)
+    assert "browserName" in caps
+    assert caps["browserName"].lower() == "safari"


### PR DESCRIPTION
selenium 4.38.0 

**Destination channel:** Defaults

### Links

- [PKG-10519]
- dev_url:        https://github.com/SeleniumHQ/selenium//tree/selenium-4.38.0
- conda_forge:    https://github.com/conda-forge/selenium-feedstock
- pypi:           https://pypi.org/project/selenium/4.38.0
- pypi inspector: https://inspector.pypi.io/project/selenium/4.38.0

### Explanation of changes:

- new version number 4.24.0 -> 4.38.0
- changed python skip from <38 to <310
- updated run dependencies versions and ranges
- updated license_file to include LICENSE and NOTICE



[PKG-10519]: https://anaconda.atlassian.net/browse/PKG-10519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ